### PR TITLE
fix(zia): strip emails from user names in datasource processor (SUP-3…

### DIFF
--- a/terraformutils/helpers/datasource_processor.go
+++ b/terraformutils/helpers/datasource_processor.go
@@ -655,6 +655,9 @@ func GenerateDataSourceFile(workingDir string, dataSourceIDs []CollectedDataSour
 			// For data sources that should be queried by name for readability.
 			// Look up the name from the ID-to-name registry.
 			if name, ok := LookupNameByID(dsID.ID); ok {
+				if dsID.DataSourceType == "zia_user_management" {
+					name = strings.TrimSpace(strings.Split(name, "(")[0])
+				}
 				if enumVal, needsEnum := queryWithEnumsDataSources[dsID.DataSourceType]; needsEnum {
 					dataSourceBlock = fmt.Sprintf(`data "%s" "%s" {
   name  = "%s"


### PR DESCRIPTION
…921)

Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points.

## Description

It is related to ticket SUP-3921
When the datasource file is generated usermanes are being pulled in incorrect format which gives the issue while doing terraform plan as it cannot find the user.
**Incorrect Format:-**
data "zia_user_management" "this_159329072" {

  name = "ZCC User(zcc@psaraswat.zscloud.net)"

}

**Error:-**
Error: error getting user by name ZCC User(zcc@psaraswat.zscloud.net): user not found
│ 
│   with data.zia_user_management.this_159329072,
│   on datasource.tf line 4, in data "zia_user_management" "this_159329072":
│    4: data "zia_user_management" "this_159329072" {


To resolve the above error we need to strip the enail portion from this

## Has your change been tested?

Yes, it has been tested against my tenant.

## Screenshots (if appropriate):
<img width="470" height="317" alt="image" src="https://github.com/user-attachments/assets/4acca12e-a1d1-478a-ac1d-53786878ee40" />


## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
