### PR TITLE
fix: ZPA import/generation fixes and CLI version reporting

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ before:
 builds:
   - main: ./main.go
     ldflags:
-      - -s -w -X "github.com/zscaler/zscaler-terraformer/cmd.versionString={{.Env.VERSION}}"
+      - -s -w -X "github.com/zscaler/zscaler-terraformer/v2/terraformutils.version={{.Version}}"
     goos:
       - windows
       - linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.1.19 (July, 22 2026)
+
+
+### Notes
+
+- Release date: (July, 22 2026)
+- Supported Terraform version: **v1.x.x**
+
+## **🐛 Bug Fixes**
+
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - `zpa_provisioning_key`: the computed `provisioning_key` attribute is no longer written to the generated HCL, preventing `Value for unconfigurable attribute` errors during `terraform plan`/`apply`.
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - `zpa_server_group`: the `servers` attribute is now emitted as a single block with an `id` list (matching `app_connector_groups`) instead of a repeated `servers` block per entry.
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - `zpa_application_segment_pra`/`zpa_application_segment_inspection`: the non-configurable `enabled` attribute is no longer written within the `common_apps_dto.apps_config` block.
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - `zpa_application_segment`/`zpa_application_segment_inspection`: the `policy_style` attribute is now generated as a bool (`DUAL_POLICY_EVAL` -> `true`, `NONE` -> `false`) to match the provider schema, instead of the raw API string.
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - Fixed CLI version reporting: release builds now stamp the correct version at link time via `ldflags`, so `zscaler-terraformer --version` and `zscaler-terraformer version` report the installed release instead of a stale hardcoded value.
+
 ## 2.1.18 (July, 20 2026)
 
 

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,9 @@ TFPROVIDERLINT = tfproviderlint
 STATICCHECK = staticcheck
 BINARY_NAME = zscaler-terraformer
 
-# Fully qualified variable for use with ldflags
-LD_FLAGS=-ldflags="-X github.com/zscaler/zscaler-terraformer/cmd.versionString=$(VERSION)"
+# Fully qualified variable for use with ldflags.
+# Strip a leading "v" so the CLI (which prints "v%s") does not render "vv...".
+LD_FLAGS=-ldflags="-X github.com/zscaler/zscaler-terraformer/v2/terraformutils.version=$(VERSION:v%=%)"
 
 build:
 	@go build \

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -900,6 +900,7 @@ func generate(ctx context.Context, cmd *cobra.Command, writer io.Writer, resourc
 		resourceCount = len(jsonPayload)
 		m, _ := json.Marshal(jsonPayload)
 		_ = json.Unmarshal(m, &jsonStructData)
+		jsonStructData = helpers.NormalizePolicyStyle(resourceType, jsonStructData)
 	case "zpa_application_segment_browser_access":
 		if api.ZPAService == nil {
 			log.Fatal("ZPA service is not initialized")
@@ -926,6 +927,7 @@ func generate(ctx context.Context, cmd *cobra.Command, writer io.Writer, resourc
 		m, _ := json.Marshal(jsonPayload)
 		resourceCount = len(jsonPayload)
 		_ = json.Unmarshal(m, &jsonStructData)
+		jsonStructData = helpers.NormalizePolicyStyle(resourceType, jsonStructData)
 	case "zpa_application_segment_pra":
 		if api.ZPAService == nil {
 			log.Fatal("ZPA service is not initialized")
@@ -2574,7 +2576,7 @@ func generate(ctx context.Context, cmd *cobra.Command, writer io.Writer, resourc
 		sort.Strings(sortedBlockAttributes)
 		for _, attrName := range sortedBlockAttributes {
 			apiAttrName := nesting.MapTfFieldNameToAPI(resourceType, attrName)
-			if attrName == "id" || attrName == "tcp_port_ranges" || attrName == "udp_port_ranges" || attrName == "rule_order" || (resourceType == "zia_url_categories" && attrName == "val") || (resourceType == "ztc_provisioning_url" && attrName == "prov_url") || (resourceType == "ztc_location_template" && attrName == "template_id") || (resourceType == "zia_cloud_app_control_rule" && (attrName == "id" || attrName == "rule_id")) || (resourceType == "zia_dlp_web_rules" && attrName == "file_types") {
+			if attrName == "id" || attrName == "tcp_port_ranges" || attrName == "udp_port_ranges" || attrName == "rule_order" || (resourceType == "zia_url_categories" && attrName == "val") || (resourceType == "ztc_provisioning_url" && attrName == "prov_url") || (resourceType == "ztc_location_template" && attrName == "template_id") || (resourceType == "zia_cloud_app_control_rule" && (attrName == "id" || attrName == "rule_id")) || (resourceType == "zia_dlp_web_rules" && attrName == "file_types") || (resourceType == "zpa_provisioning_key" && attrName == "provisioning_key") {
 				continue
 			}
 

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -12,9 +12,25 @@ Track all Zscaler Terraformer Tool releases. New resources, features, and bug fi
 
 ---
 
-``Last updated: v2.1.18``
+``Last updated: v2.1.19``
 
 ---
+
+## 2.1.19 (July, 22 2026)
+
+
+### Notes
+
+- Release date: (July, 22 2026)
+- Supported Terraform version: **v1.x.x**
+
+## **🐛 Bug Fixes**
+
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - `zpa_provisioning_key`: the computed `provisioning_key` attribute is no longer written to the generated HCL, preventing `Value for unconfigurable attribute` errors during `terraform plan`/`apply`.
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - `zpa_server_group`: the `servers` attribute is now emitted as a single block with an `id` list (matching `app_connector_groups`) instead of a repeated `servers` block per entry.
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - `zpa_application_segment_pra`/`zpa_application_segment_inspection`: the non-configurable `enabled` attribute is no longer written within the `common_apps_dto.apps_config` block.
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - `zpa_application_segment`/`zpa_application_segment_inspection`: the `policy_style` attribute is now generated as a bool (`DUAL_POLICY_EVAL` -> `true`, `NONE` -> `false`) to match the provider schema, instead of the raw API string.
+- [PR #411](https://github.com/zscaler/zscaler-terraformer/pull/411) - Fixed CLI version reporting: release builds now stamp the correct version at link time via `ldflags`, so `zscaler-terraformer --version` and `zscaler-terraformer version` report the installed release instead of a stale hardcoded value.
 
 ## 2.1.18 (July, 20 2026)
 

--- a/terraformutils/helpers/datasource_processor.go
+++ b/terraformutils/helpers/datasource_processor.go
@@ -81,6 +81,7 @@ func GetDataSourceMappingsForProvider(providerPrefix string) []DataSourceMapping
 		{"applications", "zpa_application_segment"},
 		{"app_segments", "zpa_application_segment"},
 		{"appSegments", "zpa_application_segment"},
+		{"servers", "zpa_application_server"},
 
 		// ZPA Service Edge and Network Mappings
 		{"service_edges", "zpa_service_edge_controller"},

--- a/terraformutils/helpers/helpers.go
+++ b/terraformutils/helpers/helpers.go
@@ -137,6 +137,40 @@ func FilterNonPositiveOrderRules(resourceType string, data []interface{}) []inte
 	return filtered
 }
 
+// policyStyleBoolResources lists the ZPA resource types whose "policy_style"
+// attribute is modeled as a bool in the Terraform provider even though the API
+// returns it as a string ("NONE" / "DUAL_POLICY_EVAL"). The provider performs
+// the string<->bool conversion at runtime, so the generated HCL must use a bool.
+var policyStyleBoolResources = map[string]bool{
+	"zpa_application_segment":            true,
+	"zpa_application_segment_inspection": true,
+}
+
+// NormalizePolicyStyle rewrites the API "policyStyle" string value into the bool
+// expected by the Terraform provider schema for the given resource type
+// ("DUAL_POLICY_EVAL" -> true, anything else -> false). Entries that already use
+// a bool, or that omit the attribute, are left untouched. When the resource type
+// does not model policy_style as a bool, the input is returned unchanged.
+func NormalizePolicyStyle(resourceType string, data []interface{}) []interface{} {
+	if !policyStyleBoolResources[resourceType] {
+		return data
+	}
+
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if v, exists := m["policyStyle"]; exists {
+			if s, ok := v.(string); ok {
+				m["policyStyle"] = s == "DUAL_POLICY_EVAL"
+			}
+		}
+	}
+
+	return data
+}
+
 // toFloat64 best-effort converts a value decoded from JSON (or a typed struct)
 // into a float64. It returns false when the value cannot be interpreted as a
 // number.
@@ -563,6 +597,11 @@ func ListNestedBlock(fieldName string, obj interface{}) string {
 			for key, value := range m {
 				snakeKey := strcase.ToSnake(key)
 				if IsComputedAttribute(snakeKey) {
+					continue
+				}
+				// "enabled" is not configurable within common_apps_dto.apps_config;
+				// strip it to avoid unconfigurable/computed attribute errors.
+				if snakeKey == "enabled" {
 					continue
 				}
 				switch value := value.(type) {

--- a/terraformutils/nesting/nesting.go
+++ b/terraformutils/nesting/nesting.go
@@ -321,6 +321,9 @@ func NestBlocks(resourceType string, schemaBlock *tfjson.SchemaBlock, structData
 		} else if helpers.IsInList(resourceType, []string{"zpa_pra_credential_pool"}) && block == "credentials" {
 			output += helpers.ListIdsStringBlock(block, structData["credentials"])
 			continue
+		} else if helpers.IsInList(resourceType, []string{"zpa_server_group"}) && block == "servers" {
+			output += helpers.ListIdsStringBlock(block, structData["servers"])
+			continue
 		} else if helpers.IsInList(resourceType, []string{"zpa_server_group", "zpa_policy_access_rule"}) && block == "app_connector_groups" {
 			output += helpers.ListIdsStringBlock(block, structData["appConnectorGroups"])
 			continue

--- a/terraformutils/version.go
+++ b/terraformutils/version.go
@@ -1,6 +1,10 @@
 package terraformutils
 
-var version = "2.1.14"
+// version is the fallback version reported by the CLI. Release builds override
+// this at link time via -ldflags "-X .../terraformutils.version={{.Version}}"
+// (see .goreleaser.yml and the Makefile). Keep this in sync with the latest
+// release so non-release/dev builds report a sensible value.
+var version = "2.1.19"
 
 // Version returns version of provider.
 func Version() string {

--- a/tests/unit/processing/policy_style_test.go
+++ b/tests/unit/processing/policy_style_test.go
@@ -1,0 +1,77 @@
+package processing
+
+import (
+	"testing"
+
+	"github.com/zscaler/zscaler-terraformer/v2/terraformutils/helpers"
+)
+
+func TestNormalizePolicyStyle(t *testing.T) {
+	testCases := []struct {
+		name         string
+		resourceType string
+		input        []interface{}
+		expected     []interface{}
+	}{
+		{
+			name:         "DUAL_POLICY_EVAL becomes true for application segment",
+			resourceType: "zpa_application_segment",
+			input:        []interface{}{map[string]interface{}{"policyStyle": "DUAL_POLICY_EVAL"}},
+			expected:     []interface{}{map[string]interface{}{"policyStyle": true}},
+		},
+		{
+			name:         "NONE becomes false for application segment",
+			resourceType: "zpa_application_segment",
+			input:        []interface{}{map[string]interface{}{"policyStyle": "NONE"}},
+			expected:     []interface{}{map[string]interface{}{"policyStyle": false}},
+		},
+		{
+			name:         "unknown string becomes false",
+			resourceType: "zpa_application_segment",
+			input:        []interface{}{map[string]interface{}{"policyStyle": "SOMETHING"}},
+			expected:     []interface{}{map[string]interface{}{"policyStyle": false}},
+		},
+		{
+			name:         "inspection resource is also normalized",
+			resourceType: "zpa_application_segment_inspection",
+			input:        []interface{}{map[string]interface{}{"policyStyle": "DUAL_POLICY_EVAL"}},
+			expected:     []interface{}{map[string]interface{}{"policyStyle": true}},
+		},
+		{
+			name:         "missing attribute is left untouched",
+			resourceType: "zpa_application_segment",
+			input:        []interface{}{map[string]interface{}{"name": "seg1"}},
+			expected:     []interface{}{map[string]interface{}{"name": "seg1"}},
+		},
+		{
+			name:         "already bool is left untouched",
+			resourceType: "zpa_application_segment",
+			input:        []interface{}{map[string]interface{}{"policyStyle": true}},
+			expected:     []interface{}{map[string]interface{}{"policyStyle": true}},
+		},
+		{
+			name:         "unconfigured resource type is returned unchanged",
+			resourceType: "zpa_application_segment_pra",
+			input:        []interface{}{map[string]interface{}{"policyStyle": "NONE"}},
+			expected:     []interface{}{map[string]interface{}{"policyStyle": "NONE"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := helpers.NormalizePolicyStyle(tc.resourceType, tc.input)
+			if len(result) != len(tc.expected) {
+				t.Fatalf("expected %d items, got %d", len(tc.expected), len(result))
+			}
+			for i := range result {
+				got := result[i].(map[string]interface{})
+				want := tc.expected[i].(map[string]interface{})
+				for k, wantVal := range want {
+					if got[k] != wantVal {
+						t.Errorf("key %q: expected %v (%T), got %v (%T)", k, wantVal, wantVal, got[k], got[k])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses several ZPA import/generation issues reported by users and fixes incorrect CLI version reporting.

- **`zpa_provisioning_key`**: The computed `provisioning_key` attribute is no longer written to the generated HCL, preventing `Value for unconfigurable attribute` errors during `terraform plan`/`apply`.
- **`zpa_server_group`**: The `servers` attribute is now emitted as a single block with an `id` list (matching `app_connector_groups`) instead of a repeated `servers` block per entry. Server IDs are mapped to the `zpa_application_server` data source.
- **`zpa_application_segment_pra` / `zpa_application_segment_inspection`**: The non-configurable `enabled` attribute is no longer written within the `common_apps_dto.apps_config` block.
- **`zpa_application_segment` / `zpa_application_segment_inspection`**: The `policy_style` attribute is now generated as a bool (`DUAL_POLICY_EVAL` -> `true`, `NONE` -> `false`) to match the provider schema, instead of the raw API string.
- **CLI version reporting**: Release builds now stamp the correct version at link time via `ldflags` (`.goreleaser.yml`, `Makefile`), so `zscaler-terraformer --version` / `version` report the installed release instead of a stale hardcoded value. The fallback version was also bumped.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/... ./terraformutils/...`
- [x] `go test ./tests/unit/...` (all passing)
- [x] Added `tests/unit/processing/policy_style_test.go` covering the `policy_style` string->bool conversion
- [x] Manual: import a tenant containing `zpa_server_group`, `zpa_provisioning_key`, `zpa_application_segment`, and PRA/Inspection segments and run `terraform plan` to confirm no diffs/errors