### PR TITLE
fix: ZPA data source name lookups, certificate_id mapping, and HCL cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.1.20 (July, 24 2026)
+
+
+### Notes
+
+- Release date: (July, 24 2026)
+- Supported Terraform version: **v1.x.x**
+
+## **Enhancements**
+
+- [PR #412](https://github.com/zscaler/zscaler-terraformer/pull/412) - Upgraded to [Zscaler-SDK-GO v3.8.42](https://github.com/zscaler/zscaler-sdk-go/releases/tag/v3.8.42)
+
+## **🐛 Bug Fixes**
+
+- [PR #412](https://github.com/zscaler/zscaler-terraformer/pull/412) - `zpa_application_segment_browser_access`/`zpa_application_segment_inspection`: the `certificate_id` attribute (within `clientless_apps`/`apps_config`) is now mapped to a `zpa_ba_certificate` data source reference instead of the raw numeric ID. Single-value ID attributes (e.g. `certificate_id`, `segment_group_id`, `banner_id`) now resolve to their corresponding data source or imported resource references during generation.
+- [PR #412](https://github.com/zscaler/zscaler-terraformer/pull/412) - ZPA data sources in the generated `datasource.tf` (e.g. `zpa_server_group`, `zpa_segment_group`, `zpa_ba_certificate`) are now queried by `name` instead of the raw numeric `id`, with a fallback to `id` when the name is unavailable or ambiguous.
+- [PR #412](https://github.com/zscaler/zscaler-terraformer/pull/412) - Nested blocks no longer emit empty-string attributes (e.g. `zpa_application_segment_browser_access` `clientless_apps.ext_domain`/`ext_label`); optional attributes with empty values are omitted from the generated HCL instead of being written as `= ""`.
+
 ## 2.1.19 (July, 22 2026)
 
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -2538,7 +2538,8 @@ func generate(ctx context.Context, cmd *cobra.Command, writer io.Writer, resourc
 
 	for i := 0; i < resourceCount; i++ {
 		structData := jsonStructData[i].(map[string]interface{})
-		helpers.ConvertAttributes(structData) // Ensure the attributes are converted
+		helpers.RegisterNestedIDNames(structData) // Capture ID-to-name pairs for datasource generation
+		helpers.ConvertAttributes(structData)     // Ensure the attributes are converted
 
 		resourceID := ""
 		if os.Getenv("USE_STATIC_RESOURCE_IDS") == "true" {

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -12,9 +12,27 @@ Track all Zscaler Terraformer Tool releases. New resources, features, and bug fi
 
 ---
 
-``Last updated: v2.1.19``
+``Last updated: v2.1.20``
 
 ---
+
+## 2.1.20 (July, 24 2026)
+
+
+### Notes
+
+- Release date: (July, 24 2026)
+- Supported Terraform version: **v1.x.x**
+
+## **Enhancements**
+
+- [PR #412](https://github.com/zscaler/zscaler-terraformer/pull/412) - Upgraded to [Zscaler-SDK-GO v3.8.42](https://github.com/zscaler/zscaler-sdk-go/releases/tag/v3.8.42)
+
+## **🐛 Bug Fixes**
+
+- [PR #412](https://github.com/zscaler/zscaler-terraformer/pull/412) - `zpa_application_segment_browser_access`/`zpa_application_segment_inspection`: the `certificate_id` attribute (within `clientless_apps`/`apps_config`) is now mapped to a `zpa_ba_certificate` data source reference instead of the raw numeric ID. Single-value ID attributes (e.g. `certificate_id`, `segment_group_id`, `banner_id`) now resolve to their corresponding data source or imported resource references during generation.
+- [PR #412](https://github.com/zscaler/zscaler-terraformer/pull/412) - ZPA data sources in the generated `datasource.tf` (e.g. `zpa_server_group`, `zpa_segment_group`, `zpa_ba_certificate`) are now queried by `name` instead of the raw numeric `id`, with a fallback to `id` when the name is unavailable or ambiguous.
+- [PR #412](https://github.com/zscaler/zscaler-terraformer/pull/412) - Nested blocks no longer emit empty-string attributes (e.g. `zpa_application_segment_browser_access` `clientless_apps.ext_domain`/`ext_label`); optional attributes with empty values are omitted from the generated HCL instead of being written as `= ""`.
 
 ## 2.1.19 (July, 22 2026)
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/zclconf/go-cty v1.19.0
-	github.com/zscaler/zscaler-sdk-go/v3 v3.8.41
+	github.com/zscaler/zscaler-sdk-go/v3 v3.8.42
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/zclconf/go-cty v1.19.0 h1:IV8WdqYZc2c5rLX9bEoLNXKojBAp0MZPBHMIrCoa/s4=
 github.com/zclconf/go-cty v1.19.0/go.mod h1:12W89jGn3JCOIQi7infWr9m80rOkb5RNYJqXMZcN4c8=
-github.com/zscaler/zscaler-sdk-go/v3 v3.8.41 h1:DqjCj2iksA2Y1f9NFHy47f9JoVPtxQdH0/+Mnds5HyU=
-github.com/zscaler/zscaler-sdk-go/v3 v3.8.41/go.mod h1:qvdAz1F94pppQMt82mplTqY1gbfs/DComi7qJIvr9S4=
+github.com/zscaler/zscaler-sdk-go/v3 v3.8.42 h1:75mQbdAE+3/bVncnSDv8CA+9pz/ZL6jIHVy5UAN/pkw=
+github.com/zscaler/zscaler-sdk-go/v3 v3.8.42/go.mod h1:qvdAz1F94pppQMt82mplTqY1gbfs/DComi7qJIvr9S4=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=

--- a/terraformutils/helpers/datasource_processor.go
+++ b/terraformutils/helpers/datasource_processor.go
@@ -104,6 +104,11 @@ func GetDataSourceMappingsForProvider(providerPrefix string) []DataSourceMapping
 		// ZPA Cloud Browser Isolation Mappings
 		{"banner_id", "zpa_cloud_browser_isolation_banner"},
 		{"region_ids", "zpa_cloud_browser_isolation_region"},
+
+		// ZPA Certificate Mappings (e.g. clientless_apps.certificate_id in
+		// browser access, apps_config.certificate_id in inspection, PRA portals)
+		{"certificate_id", "zpa_ba_certificate"},
+		{"certificateId", "zpa_ba_certificate"},
 	}
 
 	// ZTC-specific mappings for attributes that overlap with ZIA
@@ -644,6 +649,21 @@ func GenerateDataSourceFile(workingDir string, dataSourceIDs []CollectedDataSour
 		"zia_file_type_categories":               true,
 		"zia_virtual_service_edge_cluster":       true,
 		"zia_virtual_service_edge_node":          true,
+
+		// ZPA data sources: names are unique per resource type, so they are the
+		// natural lookup key. zpa_ba_certificate is additionally gated on name
+		// uniqueness below because certificate names (CN) can be duplicated.
+		"zpa_app_connector_group":     true,
+		"zpa_server_group":            true,
+		"zpa_segment_group":           true,
+		"zpa_application_segment":     true,
+		"zpa_application_server":      true,
+		"zpa_service_edge_controller": true,
+		"zpa_pra_portal_controller":   true,
+		"zpa_trusted_network":         true,
+		"zpa_isolation_profile":       true,
+		"zpa_inspection_profile":      true,
+		"zpa_ba_certificate":          true,
 	}
 
 	// Data source types that require an additional enum filter parameter.
@@ -667,7 +687,15 @@ func GenerateDataSourceFile(workingDir string, dataSourceIDs []CollectedDataSour
 		} else if queryByNameDataSources[dsID.DataSourceType] {
 			// For data sources that should be queried by name for readability.
 			// Look up the name from the ID-to-name registry.
-			if name, ok := LookupNameByID(dsID.ID); ok {
+			name, ok := LookupNameByID(dsID.ID)
+
+			// BA certificate names come from the certificate CN and can be
+			// duplicated; only query by name when the name maps to a single ID.
+			if ok && dsID.DataSourceType == "zpa_ba_certificate" && !IsCertificateNameUnique(name) {
+				ok = false
+			}
+
+			if ok {
 				// Workaround for ZIA API inconsistency: user names are returned as
 				// "Name(email@domain.com)" but the API doesn't accept that format for lookups.
 				if dsID.DataSourceType == "zia_user_management" {
@@ -1187,6 +1215,86 @@ func ReplaceAllReferences(workingDir string, resourceMap map[string]string, data
 					processedContent = strings.Replace(processedContent, fullMatch, replacement, 1)
 					hasChanges = true
 				}
+			}
+		}
+
+		// Process single-value and array ID attributes (e.g. certificate_id = "123",
+		// segment_group_id = "123", region_ids = ["1", "2"]). These use "= value"
+		// syntax rather than a nested "{ id = [...] }" block, so the block loop above
+		// never touches them. Resource references take priority over data sources.
+		for attributeName, expectedDataSourceType := range attributeToDataSource {
+			if !strings.HasSuffix(attributeName, "_id") && !strings.HasSuffix(attributeName, "_ids") {
+				continue
+			}
+
+			if strings.HasSuffix(attributeName, "_ids") {
+				// Array form: attribute_name = ["123", "456"]
+				pattern := fmt.Sprintf(`(?m)(\b%s\s*=\s*\[)([^\]]+)(\])`, regexp.QuoteMeta(attributeName))
+				re := regexp.MustCompile(pattern)
+				processedContent = re.ReplaceAllStringFunc(processedContent, func(match string) string {
+					submatches := re.FindStringSubmatch(match)
+					if len(submatches) < 4 {
+						return match
+					}
+					prefix := submatches[1]
+					idsContent := submatches[2]
+					suffix := submatches[3]
+
+					ids := extractIDsFromContent(idsContent)
+					var processedIds []string
+					needsReplacement := false
+					for _, id := range ids {
+						if strings.Contains(id, ".") {
+							processedIds = append(processedIds, id)
+							continue
+						}
+						// Priority 1: resource reference
+						if resourceRef, exists := resourceMap[id]; exists && isResourceTypeCompatible(resourceRef, providerPrefix, expectedDataSourceType) {
+							processedIds = append(processedIds, resourceRef)
+							needsReplacement = true
+							continue
+						}
+						// Priority 2: data source reference
+						if dataSourceRef, exists := dataSourceLookup[id]; exists && strings.Contains(dataSourceRef, expectedDataSourceType) {
+							processedIds = append(processedIds, dataSourceRef)
+							needsReplacement = true
+							continue
+						}
+						processedIds = append(processedIds, `"`+id+`"`)
+					}
+					if needsReplacement {
+						hasChanges = true
+						return prefix + strings.Join(processedIds, ", ") + suffix
+					}
+					return match
+				})
+			} else {
+				// Single-value form: attribute_name = "123"
+				pattern := fmt.Sprintf(`(?m)(\b%s\s*=\s*)"([^"]+)"`, regexp.QuoteMeta(attributeName))
+				re := regexp.MustCompile(pattern)
+				processedContent = re.ReplaceAllStringFunc(processedContent, func(match string) string {
+					submatches := re.FindStringSubmatch(match)
+					if len(submatches) < 3 {
+						return match
+					}
+					prefix := submatches[1]
+					id := submatches[2]
+
+					if strings.Contains(id, ".") {
+						return match // Already a reference
+					}
+					// Priority 1: resource reference
+					if resourceRef, exists := resourceMap[id]; exists && isResourceTypeCompatible(resourceRef, providerPrefix, expectedDataSourceType) {
+						hasChanges = true
+						return prefix + resourceRef
+					}
+					// Priority 2: data source reference
+					if dataSourceRef, exists := dataSourceLookup[id]; exists && strings.Contains(dataSourceRef, expectedDataSourceType) {
+						hasChanges = true
+						return prefix + dataSourceRef
+					}
+					return match
+				})
 			}
 		}
 

--- a/terraformutils/helpers/helpers.go
+++ b/terraformutils/helpers/helpers.go
@@ -43,6 +43,11 @@ import (
 var (
 	idNameRegistryMu sync.RWMutex
 	idNameRegistry   = make(map[string]string) // "id" -> "name"
+	// certificateNameIDs tracks which distinct certificate IDs carry a given
+	// certificate name. BA certificate names come from the certificate CN and
+	// are not guaranteed unique, so datasource generation only queries a
+	// certificate by name when exactly one imported certificate ID has it.
+	certificateNameIDs = make(map[string]map[string]bool) // "name" -> set of ids
 )
 
 // RegisterIDName stores an ID-to-name mapping for later use in data source generation.
@@ -53,6 +58,29 @@ func RegisterIDName(id, name string) {
 	idNameRegistryMu.Lock()
 	defer idNameRegistryMu.Unlock()
 	idNameRegistry[id] = name
+}
+
+// RegisterCertificateIDName stores a certificate ID-to-name mapping and tracks
+// how many distinct certificate IDs share the same name (see IsCertificateNameUnique).
+func RegisterCertificateIDName(id, name string) {
+	if id == "" || name == "" {
+		return
+	}
+	idNameRegistryMu.Lock()
+	defer idNameRegistryMu.Unlock()
+	idNameRegistry[id] = name
+	if certificateNameIDs[name] == nil {
+		certificateNameIDs[name] = make(map[string]bool)
+	}
+	certificateNameIDs[name][id] = true
+}
+
+// IsCertificateNameUnique reports whether exactly one registered certificate ID
+// carries the given name, making it safe to look the certificate up by name.
+func IsCertificateNameUnique(name string) bool {
+	idNameRegistryMu.RLock()
+	defer idNameRegistryMu.RUnlock()
+	return len(certificateNameIDs[name]) == 1
 }
 
 // LookupNameByID returns the name for a given ID from the registry.
@@ -68,6 +96,73 @@ func ResetIDNameRegistry() {
 	idNameRegistryMu.Lock()
 	defer idNameRegistryMu.Unlock()
 	idNameRegistry = make(map[string]string)
+	certificateNameIDs = make(map[string]map[string]bool)
+}
+
+// siblingIDNameFields maps API ID fields to the companion name field the API
+// returns in the same payload (e.g. an application segment carries
+// segmentGroupId and segmentGroupName side by side). certificateId is handled
+// separately so duplicate certificate names can be detected.
+var siblingIDNameFields = map[string]string{
+	"segmentGroupId": "segmentGroupName",
+}
+
+// RegisterNestedIDNames recursively walks an API response payload and registers
+// every ID-to-name pair it can find: generic {id, name} objects (server groups,
+// connector groups, applications, ...) and sibling field pairs like
+// segmentGroupId/segmentGroupName. This lets datasource.tf generation emit
+// human-readable name lookups without any additional API calls.
+func RegisterNestedIDNames(data interface{}) {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		if id := stringifyID(v["id"]); id != "" {
+			if name, ok := v["name"].(string); ok && name != "" {
+				RegisterIDName(id, name)
+			}
+		}
+		for idField, nameField := range siblingIDNameFields {
+			if id := stringifyID(v[idField]); id != "" {
+				if name, ok := v[nameField].(string); ok && name != "" {
+					RegisterIDName(id, name)
+				}
+			}
+		}
+		if id := stringifyID(v["certificateId"]); id != "" {
+			if name, ok := v["certificateName"].(string); ok && name != "" {
+				RegisterCertificateIDName(id, name)
+			}
+		}
+		for _, nested := range v {
+			RegisterNestedIDNames(nested)
+		}
+	case []interface{}:
+		for _, item := range v {
+			RegisterNestedIDNames(item)
+		}
+	}
+}
+
+// stringifyID normalizes an ID value from a JSON payload to its string form.
+// Terraform references (values containing dots) are not IDs and yield "".
+func stringifyID(v interface{}) string {
+	switch id := v.(type) {
+	case string:
+		if id == "" || strings.Contains(id, ".") {
+			return ""
+		}
+		return id
+	case float64:
+		if id == 0 {
+			return ""
+		}
+		return fmt.Sprintf("%d", int64(id))
+	case int:
+		if id == 0 {
+			return ""
+		}
+		return fmt.Sprintf("%d", id)
+	}
+	return ""
 }
 
 func IsInList(item string, list []string) bool {
@@ -514,6 +609,11 @@ func ListIdsStringBlock(fieldName string, obj interface{}) string {
 		} else {
 			// This is a regular ID, add quotes
 			validItems = append(validItems, "\""+id+"\"")
+
+			// Capture the name for data source generation if available.
+			if name, ok := m["name"].(string); ok && name != "" {
+				RegisterIDName(id, name)
+			}
 		}
 	}
 

--- a/terraformutils/nesting/nesting.go
+++ b/terraformutils/nesting/nesting.go
@@ -545,6 +545,12 @@ func WriteNestedBlock(resourceType string, attributes []string, schemaBlock *tfj
 		case ty.IsPrimitiveType():
 			switch ty {
 			case cty.String, cty.Bool, cty.Number:
+				// Skip empty string values inside nested blocks so optional
+				// attributes (e.g. clientless_apps.ext_domain / ext_label) are
+				// omitted entirely instead of being emitted as `= ""`.
+				if s, ok := attrStruct[apiFieldName].(string); ok && s == "" {
+					continue
+				}
 				nestedBlockOutput += WriteAttrLine(snakeCaseAttrName, attrStruct[apiFieldName], false)
 			default:
 				log.Debugf("unexpected primitive type %q", ty.FriendlyName())

--- a/tests/unit/processing/datasource_processor_test.go
+++ b/tests/unit/processing/datasource_processor_test.go
@@ -1,12 +1,73 @@
 package processing
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/zscaler/zscaler-terraformer/v2/terraformutils/helpers"
 	"github.com/zscaler/zscaler-terraformer/v2/tests/testutils"
 )
+
+// TestCertificateIDDataSourceMapping verifies that the clientless_apps.certificate_id
+// single-value attribute is collected and rewritten to a zpa_ba_certificate data
+// source reference (instead of being left as a raw numeric ID).
+func TestCertificateIDDataSourceMapping(t *testing.T) {
+	dir := t.TempDir()
+	hcl := `resource "zpa_application_segment_browser_access" "x" {
+  name = "x"
+  clientless_apps {
+    name           = "app1.example.com"
+    domain         = "app1.example.com"
+    certificate_id = "72058304855085464"
+  }
+  clientless_apps {
+    name           = "app2.example.com"
+    domain         = "app2.example.com"
+    certificate_id = "72058304855085464"
+  }
+}
+`
+	tfPath := filepath.Join(dir, "zpa_application_segment_browser_access.tf")
+	if err := os.WriteFile(tfPath, []byte(hcl), 0644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	// Collect data source IDs (certificate not imported -> no resource map entry).
+	dataSourceIDs, err := helpers.CollectDataSourceIDs(dir, map[string]string{}, false)
+	if err != nil {
+		t.Fatalf("CollectDataSourceIDs: %v", err)
+	}
+
+	foundCert := false
+	for _, ds := range dataSourceIDs {
+		if ds.DataSourceType == "zpa_ba_certificate" && ds.ID == "72058304855085464" {
+			foundCert = true
+		}
+	}
+	if !foundCert {
+		t.Fatalf("expected zpa_ba_certificate data source to be collected, got: %+v", dataSourceIDs)
+	}
+
+	if err := helpers.ReplaceAllReferences(dir, map[string]string{}, dataSourceIDs, false); err != nil {
+		t.Fatalf("ReplaceAllReferences: %v", err)
+	}
+
+	out, err := os.ReadFile(tfPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	got := string(out)
+
+	want := "certificate_id = data.zpa_ba_certificate.this_72058304855085464.id"
+	if !strings.Contains(got, want) {
+		t.Errorf("expected %q in output, got:\n%s", want, got)
+	}
+	if strings.Contains(got, `certificate_id = "72058304855085464"`) {
+		t.Errorf("raw certificate_id should have been replaced, got:\n%s", got)
+	}
+}
 
 func TestDataSourceMappingResolution(t *testing.T) {
 	// Test data source mapping logic for ZIA
@@ -306,5 +367,186 @@ func TestReferenceReplacement(t *testing.T) {
 			testutils.AssertContains(t, tc.expectedHCL, "data.", "Replaced HCL should contain data source reference")
 			testutils.AssertContains(t, tc.expectedHCL, tc.dataSourceType, "Replaced HCL should contain correct data source type")
 		})
+	}
+}
+
+// TestRegisterNestedIDNames verifies that the recursive payload walker registers
+// generic {id, name} objects, sibling field pairs (segmentGroupId/segmentGroupName),
+// and certificate pairs (certificateId/certificateName) at any nesting depth.
+func TestRegisterNestedIDNames(t *testing.T) {
+	helpers.ResetIDNameRegistry()
+	t.Cleanup(helpers.ResetIDNameRegistry)
+
+	payload := map[string]interface{}{
+		"id":               "72058304855181170",
+		"name":             "App01",
+		"segmentGroupId":   "72058304855181174",
+		"segmentGroupName": "Example200",
+		"serverGroups": []interface{}{
+			map[string]interface{}{
+				"id":   "72058304855181176",
+				"name": "Example200_SG",
+			},
+		},
+		"clientlessApps": []interface{}{
+			map[string]interface{}{
+				"id":              "72058304855181180",
+				"name":            "app01.example.com",
+				"certificateId":   "72058304855085464",
+				"certificateName": "wildcard.example.com",
+			},
+		},
+	}
+
+	helpers.RegisterNestedIDNames(payload)
+
+	expected := map[string]string{
+		"72058304855181170": "App01",                // top-level {id, name}
+		"72058304855181174": "Example200",           // sibling segmentGroupId/Name pair
+		"72058304855181176": "Example200_SG",        // nested server group object
+		"72058304855181180": "app01.example.com",    // nested clientless app object
+		"72058304855085464": "wildcard.example.com", // certificateId/Name pair
+	}
+	for id, wantName := range expected {
+		name, ok := helpers.LookupNameByID(id)
+		if !ok {
+			t.Errorf("expected ID %s to be registered", id)
+			continue
+		}
+		if name != wantName {
+			t.Errorf("ID %s: got name %q, want %q", id, name, wantName)
+		}
+	}
+
+	if !helpers.IsCertificateNameUnique("wildcard.example.com") {
+		t.Error("certificate name registered once should be unique")
+	}
+}
+
+// TestZPADataSourceGeneratedByName verifies that ZPA data sources in datasource.tf
+// are emitted with a name lookup when the ID-to-name registry has the name, and
+// fall back to an id lookup when it does not.
+func TestZPADataSourceGeneratedByName(t *testing.T) {
+	helpers.ResetIDNameRegistry()
+	t.Cleanup(helpers.ResetIDNameRegistry)
+
+	helpers.RegisterIDName("72058304855181176", "Example200_SG")
+	helpers.RegisterIDName("72058304855181174", "Example200")
+	// No name registered for 72058304855099999 -> id fallback expected.
+
+	dir := t.TempDir()
+	dataSourceIDs := []helpers.CollectedDataSourceID{
+		{DataSourceType: "zpa_server_group", ID: "72058304855181176", UniqueName: "this_72058304855181176"},
+		{DataSourceType: "zpa_segment_group", ID: "72058304855181174", UniqueName: "this_72058304855181174"},
+		{DataSourceType: "zpa_app_connector_group", ID: "72058304855099999", UniqueName: "this_72058304855099999"},
+	}
+
+	if err := helpers.GenerateDataSourceFile(dir, dataSourceIDs, false); err != nil {
+		t.Fatalf("GenerateDataSourceFile: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "datasource.tf"))
+	if err != nil {
+		t.Fatalf("failed to read datasource.tf: %v", err)
+	}
+	got := string(out)
+
+	for _, want := range []string{
+		`data "zpa_server_group" "this_72058304855181176" {
+  name = "Example200_SG"
+}`,
+		`data "zpa_segment_group" "this_72058304855181174" {
+  name = "Example200"
+}`,
+		`data "zpa_app_connector_group" "this_72058304855099999" {
+  id = "72058304855099999"
+}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected datasource.tf to contain:\n%s\ngot:\n%s", want, got)
+		}
+	}
+
+	if strings.Contains(got, `id = "72058304855181176"`) {
+		t.Errorf("server group with a known name should not be queried by id, got:\n%s", got)
+	}
+}
+
+// TestBACertificateNameUniquenessGate verifies that zpa_ba_certificate data
+// sources are only queried by name when the certificate name is unambiguous;
+// duplicate names (e.g. reissued certs sharing a CN) fall back to id.
+func TestBACertificateNameUniquenessGate(t *testing.T) {
+	helpers.ResetIDNameRegistry()
+	t.Cleanup(helpers.ResetIDNameRegistry)
+
+	// Unique certificate name.
+	helpers.RegisterCertificateIDName("72058304855085464", "app01.example.com")
+	// Duplicate certificate name shared by two distinct IDs.
+	helpers.RegisterCertificateIDName("72058304855085466", "wildcard.example.com")
+	helpers.RegisterCertificateIDName("72058304855085467", "wildcard.example.com")
+
+	if helpers.IsCertificateNameUnique("wildcard.example.com") {
+		t.Fatal("duplicate certificate name should not be reported unique")
+	}
+
+	dir := t.TempDir()
+	dataSourceIDs := []helpers.CollectedDataSourceID{
+		{DataSourceType: "zpa_ba_certificate", ID: "72058304855085464", UniqueName: "this_72058304855085464"},
+		{DataSourceType: "zpa_ba_certificate", ID: "72058304855085466", UniqueName: "this_72058304855085466"},
+	}
+
+	if err := helpers.GenerateDataSourceFile(dir, dataSourceIDs, false); err != nil {
+		t.Fatalf("GenerateDataSourceFile: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "datasource.tf"))
+	if err != nil {
+		t.Fatalf("failed to read datasource.tf: %v", err)
+	}
+	got := string(out)
+
+	uniqueWant := `data "zpa_ba_certificate" "this_72058304855085464" {
+  name = "app01.example.com"
+}`
+	if !strings.Contains(got, uniqueWant) {
+		t.Errorf("unique certificate name should be queried by name, got:\n%s", got)
+	}
+
+	dupWant := `data "zpa_ba_certificate" "this_72058304855085466" {
+  id = "72058304855085466"
+}`
+	if !strings.Contains(got, dupWant) {
+		t.Errorf("duplicate certificate name should fall back to id, got:\n%s", got)
+	}
+	if strings.Contains(got, `name = "wildcard.example.com"`) {
+		t.Errorf("ambiguous certificate name must not be used for lookup, got:\n%s", got)
+	}
+}
+
+// TestListIdsStringBlockRegistersNames verifies that ZPA-style string-ID blocks
+// (server_groups, app_connector_groups, ...) register their {id, name} pairs for
+// later datasource generation, mirroring ListIdsIntBlock.
+func TestListIdsStringBlockRegistersNames(t *testing.T) {
+	helpers.ResetIDNameRegistry()
+	t.Cleanup(helpers.ResetIDNameRegistry)
+
+	obj := []interface{}{
+		map[string]interface{}{"id": "72058304855181176", "name": "Example200_SG"},
+		map[string]interface{}{"id": "72058304855181177", "name": "Example201_SG"},
+	}
+
+	out := helpers.ListIdsStringBlock("server_groups", obj)
+	if !strings.Contains(out, `"72058304855181176"`) || !strings.Contains(out, `"72058304855181177"`) {
+		t.Fatalf("block output should contain both IDs, got: %s", out)
+	}
+
+	for id, wantName := range map[string]string{
+		"72058304855181176": "Example200_SG",
+		"72058304855181177": "Example201_SG",
+	} {
+		name, ok := helpers.LookupNameByID(id)
+		if !ok || name != wantName {
+			t.Errorf("ID %s: got (%q, %v), want (%q, true)", id, name, ok, wantName)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **`certificate_id` → data source**: `clientless_apps` / `apps_config` `certificate_id` is now mapped to a `zpa_ba_certificate` data source reference instead of the raw numeric ID.
- **Single-value ID resolution**: single-value and array ID attributes (`certificate_id`, `segment_group_id`, `banner_id`, `region_ids`, ...) now resolve to their corresponding data source or imported resource references during generation (previously left as raw IDs).
- **Name-based data source lookups**: ZPA data sources (`zpa_server_group`, `zpa_segment_group`, `zpa_ba_certificate`) are generated querying by `name` with an `id` fallback; certificate name lookups are gated on name uniqueness.
- **ID→name registry**: ID-to-name pairs are recorded from nested API payloads so `datasource.tf` can emit readable name lookups without extra API calls.
- **Empty attribute cleanup**: nested blocks no longer emit empty-string attributes (e.g. `clientless_apps.ext_domain` / `ext_label`) as `= ""`.
- **SDK**: upgraded to Zscaler-SDK-GO v3.8.42.

## Test plan

- [x] `go build ./...`
- [x] `go test ./tests/unit/...` (includes new `TestCertificateIDDataSourceMapping`)
- [ ] Import a `zpa_application_segment_browser_access` with `clientless_apps` and verify `certificate_id` resolves to `data.zpa_ba_certificate.*.id` and no empty `ext_domain`/`ext_label` are emitted
- [ ] Verify generated `datasource.tf` queries `zpa_server_group` / `zpa_segment_group` / `zpa_ba_certificate` by `name` (with `id` fallback)